### PR TITLE
Add windows property to HAXApplication

### DIFF
--- a/Classes/HAXApplication.h
+++ b/Classes/HAXApplication.h
@@ -9,5 +9,6 @@
 @interface HAXApplication : HAXElement
 
 @property (nonatomic, readonly) HAXWindow *focusedWindow;
+@property (nonatomic, readonly) NSArray *windows;
 
 @end

--- a/Classes/HAXApplication.m
+++ b/Classes/HAXApplication.m
@@ -23,4 +23,13 @@
 	return [self elementOfClass:[HAXWindow class] forKey:(NSString *)kAXFocusedWindowAttribute error:&error];
 }
 
+-(NSArray *)windows {
+    NSArray *axWindowObjects = (__bridge_transfer NSArray *)[self copyAttributeValueForKey:(NSString *)kAXWindowsAttribute error:nil];
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:[axWindowObjects count]];
+    for (id axObject in axWindowObjects) {
+        [result addObject:[HAXWindow elementWithElementRef:(AXUIElementRef)axObject]];
+    }
+    return result;
+}
+
 @end


### PR DESCRIPTION
Returns an array of `HAXWindow` objects for all the windows owned by the application.

Relies on ARC, so blocked by https://github.com/robrix/Haxcessibility/pull/6
