### PR TITLE
Simple correctness update to the README.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -7,6 +7,6 @@ It also enables hacks like moving and resizing another app’s windows.
 
 # Use it
 
-	[HAXSystem element].focusedApplication.focusedWindow.size = NSMakeRect(0, 0, 2560, 1440);
+	[HAXSystem system].focusedApplication.focusedWindow.size = NSMakeRect(0, 0, 2560, 1440);
 
 More features are, obviously, desirable.


### PR DESCRIPTION
`HAXSystem` doesn't have an `+element` method, but it does have `+system`.
