### PR TITLE
Proper isEqual and hash implementations for HAXElement

### DIFF
--- a/Classes/HAXElement.m
+++ b/Classes/HAXElement.m
@@ -32,6 +32,17 @@
 }
 
 
+- (BOOL)isEqual:(id)object
+{
+    return [object isKindOfClass:[self class]] && CFEqual([self elementRef], [object elementRef]);
+}
+
+- (NSUInteger)hash
+{
+    return CFHash(self.elementRef);
+}
+
+
 -(CFTypeRef)copyAttributeValueForKey:(NSString *)key error:(NSError **)error {
 	NSParameterAssert(key != nil);
 	CFTypeRef attributeRef = NULL;


### PR DESCRIPTION
The Accessibility docs claim that an `AXUIElementRef` is useful for comparisons against other objects that apply to the same UI element using `CFEqual` and `CFHash`, even when it is invalid. The Haxcessibility wrapper objects should behave similarly.
