### PR TITLE
Lazy notification registration and a deregistration bugfix.

### DIFF
--- a/Classes/HAXElement.m
+++ b/Classes/HAXElement.m
@@ -25,12 +25,12 @@
 }
 
 -(void)dealloc {
+	if (_observer) {
+		[self removeAXObserver];
+	}
 	if (_elementRef) {
 		CFRelease(_elementRef);
 		_elementRef = NULL;
-	}
-	if (_observer) {
-		[self removeAXObserver];
 	}
 }
 
@@ -52,10 +52,10 @@
 
 - (void)setDelegate:(id<HAXElementDelegate>)delegate;
 {
-    if (delegate && !_observer) {
-        [self addAXObserver];
-    }
-    _delegate = delegate;
+	if (delegate && !_observer) {
+		[self addAXObserver];
+	}
+	_delegate = delegate;
 }
 
 
@@ -112,6 +112,8 @@
 
 
 -(void)addAXObserver {
+	if (self.observer) { return; }
+	
 	AXObserverRef observer;
 	AXError err;
 	pid_t pid;

--- a/Classes/HAXElement.m
+++ b/Classes/HAXElement.m
@@ -20,7 +20,6 @@
 -(instancetype)initWithElementRef:(AXUIElementRef)elementRef {
 	if((self = [super init])) {
 		_elementRef = CFRetain(elementRef);
-		[self addAXObserver];
 	}
 	return self;
 }
@@ -48,6 +47,15 @@
 
 -(NSUInteger)hash {
 	return CFHash(self.elementRef);
+}
+
+
+- (void)setDelegate:(id<HAXElementDelegate>)delegate;
+{
+    if (delegate && !_observer) {
+        [self addAXObserver];
+    }
+    _delegate = delegate;
 }
 
 


### PR DESCRIPTION
- IPC is expensive, so only register for notifications when necessary.
- This has not been a problem yet, but for Future Us `addAXObserver` will early return if the element has already registered an observer.
- Remove the observer before the element. The bug was as follows:
  - `HAXElement dealloc`
  - Release `elementRef`
  - Deregister `observer`, which fails because `elementRef` is gone
  - Receive notification with an invalid object pointer for `refcon` (After `self` finished `dealloc`)
  - Crash
