### PR TITLE
Merge changes adapted from okocsis:develop

### DIFF
--- a/Classes/HAXApplication.h
+++ b/Classes/HAXApplication.h
@@ -10,11 +10,9 @@
 
 @property (nonatomic, readonly) HAXWindow *focusedWindow;
 @property (nonatomic, readonly) NSArray *windows;
+@property (nonatomic, copy, readonly) NSString *localizedName;
+@property (nonatomic, readonly) pid_t processIdentifier;
 
 +(instancetype)applicationWithPID:(pid_t)pid;
-
-@property (nonatomic, copy, readonly) NSString *localizedName;
-
-@property (nonatomic, readonly) pid_t processIdentifier;
 
 @end

--- a/Classes/HAXApplication.m
+++ b/Classes/HAXApplication.m
@@ -8,7 +8,7 @@
 
 @implementation HAXApplication
 
-+(instancetype)applicationWithPID:(pid_t)pid; {
++(instancetype)applicationWithPID:(pid_t)pid {
 	AXUIElementRef app = AXUIElementCreateApplication(pid);
 	id result = nil;
 	if (app) {
@@ -19,12 +19,11 @@
 }
 
 -(HAXWindow *)focusedWindow {
-	NSError *error = nil;
-	return [self elementOfClass:[HAXWindow class] forKey:(NSString *)kAXFocusedWindowAttribute error:&error];
+	return [self elementOfClass:[HAXWindow class] forKey:(NSString *)kAXFocusedWindowAttribute error:NULL];
 }
 
 -(NSArray *)windows {
-	NSArray *axWindowObjects = CFBridgingRelease([self copyAttributeValueForKey:(NSString *)kAXWindowsAttribute error:nil]);
+	NSArray *axWindowObjects = [self getAttributeValueForKey:(NSString *)kAXWindowsAttribute error:NULL];
 	NSMutableArray *result = [NSMutableArray arrayWithCapacity:[axWindowObjects count]];
 	for (id axObject in axWindowObjects) {
 		[result addObject:[HAXWindow elementWithElementRef:(AXUIElementRef)axObject]];
@@ -32,11 +31,9 @@
 	return result;
 }
 
-
 -(NSString *)localizedName {
-	return [self copyAttributeValueForKey:(NSString *)kAXTitleAttribute error:NULL];
+	return [self getAttributeValueForKey:(NSString *)kAXTitleAttribute error:NULL];
 }
-
 
 -(pid_t)processIdentifier {
 	pid_t processIdentifier = 0;

--- a/Classes/HAXButton.h
+++ b/Classes/HAXButton.h
@@ -1,0 +1,11 @@
+//  HAXButton.h
+//  Created by Kocsis Olivér on 2014-05-21
+//  Copyright 2014 Joinect Technologies
+
+#import <HAXcessibility/HAXView.h>
+
+@interface HAXButton : HAXView
+
+-(void)press;
+
+@end

--- a/Classes/HAXButton.m
+++ b/Classes/HAXButton.m
@@ -1,0 +1,14 @@
+//  HAXButton.m
+//  Created by Kocsis Olivér on 2014-05-21
+//  Copyright 2014 Joinect Technologies
+
+#import "HAXButton.h"
+#import "HAXElement+Protected.h"
+
+@implementation HAXButton
+
+-(void)press {
+    [self performAction:(__bridge NSString *)kAXPressAction error:NULL];
+}
+
+@end

--- a/Classes/HAXElement+Protected.h
+++ b/Classes/HAXElement+Protected.h
@@ -11,9 +11,10 @@
 
 @property (nonatomic, readonly) AXUIElementRef elementRef __attribute__((NSObject));
 
+-(id)getAttributeValueForKey:(NSString *)key error:(NSError **)error __attribute__((nonnull(1)));
 -(CFTypeRef)copyAttributeValueForKey:(NSString *)key error:(NSError **)error __attribute__((nonnull(1)));
--(bool)setAttributeValue:(CFTypeRef)value forKey:(NSString *)key error:(NSError **)error __attribute__((nonnull(1,2)));
--(bool)performAction:(NSString *)action error:(NSError **)error __attribute__((nonnull(1)));
+-(BOOL)setAttributeValue:(CFTypeRef)value forKey:(NSString *)key error:(NSError **)error __attribute__((nonnull(1,2)));
+-(BOOL)performAction:(NSString *)action error:(NSError **)error __attribute__((nonnull(1)));
 
 -(id)elementOfClass:(Class)klass forKey:(NSString *)key error:(NSError **)error __attribute__((nonnull(1,2)));
 

--- a/Classes/HAXElement.h
+++ b/Classes/HAXElement.h
@@ -9,8 +9,14 @@
 @interface HAXElement : NSObject
 
 @property (nonatomic, weak) id<HAXElementDelegate> delegate;
+@property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) NSString *role;
+@property (nonatomic, readonly) BOOL hasChildren;
+@property (nonatomic, readonly) NSArray *children;
+@property (nonatomic, readonly) NSArray *attributeNames;
+@property (nonatomic, readonly) NSArray *buttons;
 
--(bool)isEqualToElement:(HAXElement *)other;
+-(BOOL)isEqualToElement:(HAXElement *)other;
 
 @end
 

--- a/Classes/HAXSystem.m
+++ b/Classes/HAXSystem.m
@@ -17,8 +17,7 @@
 
 
 -(HAXApplication *)focusedApplication {
-	NSError *error = nil;
-	return [self elementOfClass:[HAXApplication class] forKey:(NSString *)kAXFocusedApplicationAttribute error:&error];
+	return [self elementOfClass:[HAXApplication class] forKey:(NSString *)kAXFocusedApplicationAttribute error:NULL];
 }
 
 @end

--- a/Classes/HAXView.h
+++ b/Classes/HAXView.h
@@ -1,0 +1,19 @@
+//  HAXView.h
+//  Created by Kocsis Olivér on 2014-05-12
+//  Copyright 2014 Joinect Technologies
+
+#import <Cocoa/Cocoa.h>
+#import <Haxcessibility/HAXElement.h>
+
+@interface HAXView : HAXElement
+
+@property (nonatomic, assign) CGPoint carbonOrigin;
+@property (nonatomic, assign, readonly) NSPoint origin;
+@property (nonatomic, assign) NSSize size;
+@property (nonatomic, assign) CGRect carbonFrame;
+@property (nonatomic, assign, readonly) NSRect frame;
+@property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) NSScreen *screen;
+@property (nonatomic, readonly, getter=isFullscreen) BOOL fullscreen;
+
+@end

--- a/Classes/HAXView.m
+++ b/Classes/HAXView.m
@@ -1,0 +1,98 @@
+//  HAXView.m
+//  Created by Kocsis Olivér on 2014-05-12
+//  Copyright 2014 Joinect Technologies
+
+#import "HAXView.h"
+#import "HAXElement+Protected.h"
+#import "NSScreen+HAXPointConvert.h"
+
+@implementation HAXView
+
+-(CGPoint)carbonOrigin {
+    CGPoint origin = {0};
+    AXValueRef originRef = (AXValueRef)[self copyAttributeValueForKey:(__bridge NSString *)kAXPositionAttribute error:NULL];
+    if(originRef) {
+        AXValueGetValue(originRef, kAXValueCGPointType, &origin);
+        CFRelease(originRef);
+        originRef = NULL;
+    }
+    return origin;
+}
+
+-(void)setCarbonOrigin:(CGPoint)carbonOrigin {
+    AXValueRef originRef = AXValueCreate(kAXValueCGPointType, &carbonOrigin);
+    [self setAttributeValue:originRef forKey:(__bridge NSString *)kAXPositionAttribute error:NULL];
+    CFRelease(originRef);
+}
+
+-(NSPoint)origin {
+    return [NSScreen hax_cocoaScreenFrameFromCarbonScreenFrame:self.carbonFrame].origin;
+}
+
+-(NSSize)size {
+    CGSize size = {0};
+    AXValueRef sizeRef = (AXValueRef)[self copyAttributeValueForKey:(__bridge NSString *)kAXSizeAttribute error:NULL];
+    if(sizeRef) {
+        AXValueGetValue(sizeRef, kAXValueCGSizeType, &size);
+        CFRelease(sizeRef);
+        sizeRef = NULL;
+    }
+    return size;
+}
+
+-(void)setSize:(NSSize)size {
+    AXValueRef sizeRef = AXValueCreate(kAXValueCGSizeType, &size);
+    [self setAttributeValue:sizeRef forKey:(__bridge NSString *)kAXSizeAttribute error:NULL];
+    CFRelease(sizeRef);
+}
+
+-(CGRect)carbonFrame {
+	return (CGRect){ .origin = self.carbonOrigin, .size = self.size };
+}
+
+-(void)setCarbonFrame:(CGRect)carbonFrame {
+    self.carbonOrigin = carbonFrame.origin;
+    self.size = carbonFrame.size;
+}
+
+-(NSRect)frame {
+    return [NSScreen hax_cocoaScreenFrameFromCarbonScreenFrame:self.carbonFrame];
+}
+
+-(NSString *)title {
+	return [self getAttributeValueForKey:(__bridge NSString *)kAXTitleAttribute error:NULL];
+}
+
+-(NSScreen *)screen {
+    NSScreen *matchingScreen = nil;
+    NSRect viewFrame = self.frame;
+    NSUInteger bestOverlap = 0;
+    for (NSScreen * screenI in [NSScreen screens]) {
+        NSRect intersection = NSIntersectionRect(screenI.frame, viewFrame);
+        NSUInteger intersectionOverlap = intersection.size.width * intersection.size.height;
+        if(intersectionOverlap > bestOverlap) {
+            matchingScreen = screenI;
+            bestOverlap = intersectionOverlap;
+        }
+    }
+    return matchingScreen;
+}
+
+-(BOOL)isFullscreen {
+    BOOL isFullScreen = NO;
+    NSArray * sceenArray = [NSScreen screens];
+    NSRect windowFrame = self.frame;
+
+    for (NSScreen * screenI in sceenArray) {
+        NSRect screenFrame;
+        screenFrame = [screenI frame];
+        if(NSEqualRects(screenFrame, windowFrame)) {
+            isFullScreen = YES;
+            break;
+        }
+    }
+    
+    return isFullScreen;
+}
+
+@end

--- a/Classes/HAXWindow.h
+++ b/Classes/HAXWindow.h
@@ -2,17 +2,14 @@
 // Created by Rob Rix on 2011-01-06
 // Copyright 2011 Rob Rix
 
-#import <Haxcessibility/HAXElement.h>
+#import <Cocoa/Cocoa.h>
+#import <Haxcessibility/HAXView.h>
 
-@interface HAXWindow : HAXElement
+@interface HAXWindow : HAXView
 
-@property (nonatomic, assign) CGPoint origin;
-@property (nonatomic, assign) CGSize size;
-@property (nonatomic, assign) CGRect frame;
+@property (nonatomic, readonly) NSArray *views;
 
-@property (nonatomic, readonly) NSString *title;
-
--(bool)raise;
--(bool)close;
+-(BOOL)raise;
+-(BOOL)close;
 
 @end

--- a/Classes/HAXWindow.m
+++ b/Classes/HAXWindow.m
@@ -7,62 +7,26 @@
 
 @implementation HAXWindow
 
--(CGPoint)origin {
-	CGPoint origin = {0};
-	CFTypeRef originRef = [self copyAttributeValueForKey:(__bridge NSString *)kAXPositionAttribute error:NULL];
-	if(originRef) {
-		AXValueGetValue(originRef, kAXValueCGPointType, &origin);
-		CFRelease(originRef);
-		originRef = NULL;
-	}
-	return origin;
+-(NSArray *)views {
+	NSArray *axChildren = self.children;
+    NSMutableArray *result = [NSMutableArray array];
+    
+    NSString * axRole;
+    for (HAXElement * haxElementI in axChildren) {
+        axRole = [haxElementI getAttributeValueForKey:(__bridge NSString *)kAXRoleAttribute error:NULL];
+        if ([axRole isEqualToString:@"AXView"]) {
+            HAXView * haxView = [HAXView elementWithElementRef:(AXUIElementRef)haxElementI.elementRef];
+            [result addObject:haxView];
+        }
+    }
+	return result;
 }
 
--(void)setOrigin:(CGPoint)origin {
-	AXValueRef originRef = AXValueCreate(kAXValueCGPointType, &origin);
-	[self setAttributeValue:originRef forKey:(__bridge NSString *)kAXPositionAttribute error:NULL];
-	CFRelease(originRef);
-}
-
-
--(CGSize)size {
-	CGSize size = {0};
-	CFTypeRef sizeRef = [self copyAttributeValueForKey:(__bridge NSString *)kAXSizeAttribute error:NULL];
-	if(sizeRef) {
-		AXValueGetValue(sizeRef, kAXValueCGSizeType, &size);
-		CFRelease(sizeRef);
-		sizeRef = NULL;
-	}
-	return size;
-}
-
--(void)setSize:(CGSize)size {
-	AXValueRef sizeRef = AXValueCreate(kAXValueCGSizeType, &size);
-	[self setAttributeValue:sizeRef forKey:(__bridge NSString *)kAXSizeAttribute error:NULL];
-	CFRelease(sizeRef);
-}
-
-
--(CGRect)frame {
-	return (CGRect){ .origin = self.origin, .size = self.size };
-}
-
--(void)setFrame:(CGRect)frame {
-	self.origin = frame.origin;
-	self.size = frame.size;
-}
-
-
--(NSString *)title {
-	return CFBridgingRelease([self copyAttributeValueForKey:(__bridge NSString *)kAXTitleAttribute error:NULL]);
-}
-
-
--(bool)raise {
+-(BOOL)raise {
 	return [self performAction:(__bridge NSString *)kAXRaiseAction error:NULL];
 }
 
--(bool)close {
+-(BOOL)close {
 	HAXElement *element = [self elementOfClass:[HAXElement class] forKey:(__bridge NSString *)kAXCloseButtonAttribute error:NULL];
 	return [element performAction:(__bridge NSString *)kAXPressAction error:NULL];
 }

--- a/Classes/NSScreen+HAXPointConvert.h
+++ b/Classes/NSScreen+HAXPointConvert.h
@@ -1,0 +1,14 @@
+//  NSScreen+HAXPointConvert.h
+//  Created by Kocsis Olivér on 2014-05-05
+//  Copyright 2014 Joinect Technologies
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSScreen (HAXPointConvert)
+
+- (NSRect)hax_frameCarbon;
++ (NSScreen*)hax_screenWithPoint:(NSPoint)p;
++ (NSRect)hax_cocoaScreenFrameFromCarbonScreenFrame:(CGRect)carbonPoint;
++ (CGPoint)hax_carbonScreenPointFromCocoaScreenPoint:(NSPoint)cocoaPoint;
+
+@end

--- a/Classes/NSScreen+HAXPointConvert.m
+++ b/Classes/NSScreen+HAXPointConvert.m
@@ -1,0 +1,64 @@
+//  NSScreen+HAXPointConvert.m
+//  Created by Kocsis Olivér on 2014-05-05
+//  Copyright 2014 Joinect Technologies
+
+#import "NSScreen+HAXPointConvert.h"
+
+@implementation NSScreen (HAXPointConvert)
+
++ (NSScreen*)hax_screenWithPoint:(NSPoint)p {
+    NSScreen *screen = nil;
+    for (NSScreen *screenI in [NSScreen screens]) {
+        if (NSPointInRect(p, [screenI frame])) {
+            screen = screenI;
+            break;
+        }
+    }
+    return screen;
+}
+
+- (NSRect)hax_frameCarbon {
+    NSRect originScreenFrame = ((NSScreen *)[NSScreen screens][0]).frame;
+    
+    NSRect carbonFrame;
+    carbonFrame.origin=  NSMakePoint([self frame].origin.x,
+                                    originScreenFrame.size.height -
+                                    [self frame].origin.y -
+                                    [self frame].size.height );;
+    carbonFrame.size = [self frame].size;
+    return carbonFrame;
+}
+
++ (NSRect)hax_cocoaScreenFrameFromCarbonScreenFrame:(CGRect)carbonPoint {
+    NSRect originScreenFrame = ((NSScreen *)[NSScreen screens][0]).frame;
+    
+    NSRect cocoaFrame;
+    cocoaFrame.origin=  NSMakePoint(carbonPoint.origin.x,
+                                    originScreenFrame.size.height -
+                                    carbonPoint.origin.y -
+                                    carbonPoint.size.height );;
+    cocoaFrame.size = carbonPoint.size;
+    return cocoaFrame;
+}
+
++ (CGPoint)hax_carbonScreenPointFromCocoaScreenPoint:(NSPoint)cocoaPoint {
+    NSScreen *foundScreen = nil;
+    CGPoint thePoint;
+    
+    for (NSScreen *screen in [NSScreen screens]) {
+        if (NSPointInRect(cocoaPoint, [screen frame])) {
+            foundScreen = screen;
+        }
+    }
+    
+    if (foundScreen) {
+        CGFloat screenHeight = [foundScreen frame].size.height;
+        thePoint = CGPointMake(cocoaPoint.x, screenHeight - cocoaPoint.y - 1);
+    } else {
+        thePoint = CGPointMake(0.0, 0.0);
+    }
+    
+    return thePoint;
+}
+
+@end

--- a/Haxcessibility.xcodeproj/project.pbxproj
+++ b/Haxcessibility.xcodeproj/project.pbxproj
@@ -10,6 +10,12 @@
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 		BC3B3B76175E9FD4002AD452 /* HAXElement+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = D44E051312D75B3D00541D6A /* HAXElement+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C3E21520194F381400C85776 /* HAXButton.h in Headers */ = {isa = PBXBuildFile; fileRef = C3E2151C194F381400C85776 /* HAXButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3E21521194F381400C85776 /* HAXButton.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E2151D194F381400C85776 /* HAXButton.m */; };
+		C3E21526194F38BE00C85776 /* NSScreen+HAXPointConvert.h in Headers */ = {isa = PBXBuildFile; fileRef = C3E21524194F38BD00C85776 /* NSScreen+HAXPointConvert.h */; };
+		C3E21527194F38BE00C85776 /* NSScreen+HAXPointConvert.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E21525194F38BD00C85776 /* NSScreen+HAXPointConvert.m */; };
+		C3E2152A194F38FB00C85776 /* HAXView.h in Headers */ = {isa = PBXBuildFile; fileRef = C3E21528194F38FB00C85776 /* HAXView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3E2152B194F38FB00C85776 /* HAXView.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E21529194F38FB00C85776 /* HAXView.m */; };
 		D4D2103412D6957000509E57 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D2103312D6957000509E57 /* Carbon.framework */; };
 		D4D2103712D6959400509E57 /* HAXElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D4D2103512D6959400509E57 /* HAXElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D4D2103812D6959400509E57 /* HAXElement.m in Sources */ = {isa = PBXBuildFile; fileRef = D4D2103612D6959400509E57 /* HAXElement.m */; };
@@ -28,6 +34,12 @@
 		32DBCF5E0370ADEE00C91783 /* Haxcessibility.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Haxcessibility.pch; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* Haxcessibility.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Haxcessibility.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3E2151C194F381400C85776 /* HAXButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HAXButton.h; sourceTree = "<group>"; };
+		C3E2151D194F381400C85776 /* HAXButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HAXButton.m; sourceTree = "<group>"; };
+		C3E21524194F38BD00C85776 /* NSScreen+HAXPointConvert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSScreen+HAXPointConvert.h"; sourceTree = "<group>"; };
+		C3E21525194F38BD00C85776 /* NSScreen+HAXPointConvert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSScreen+HAXPointConvert.m"; sourceTree = "<group>"; };
+		C3E21528194F38FB00C85776 /* HAXView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HAXView.h; sourceTree = "<group>"; };
+		C3E21529194F38FB00C85776 /* HAXView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HAXView.m; sourceTree = "<group>"; };
 		D44E051312D75B3D00541D6A /* HAXElement+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "HAXElement+Protected.h"; sourceTree = "<group>"; };
 		D4D2103312D6957000509E57 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		D4D2103512D6959400509E57 /* HAXElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HAXElement.h; sourceTree = "<group>"; };
@@ -104,13 +116,19 @@
 		D4D2102E12D6947D00509E57 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				C3E21524194F38BD00C85776 /* NSScreen+HAXPointConvert.h */,
+				C3E21525194F38BD00C85776 /* NSScreen+HAXPointConvert.m */,
 				D4D2106B12D69C8900509E57 /* HAXApplication.h */,
 				D4D2106C12D69C8B00509E57 /* HAXApplication.m */,
+				C3E2151C194F381400C85776 /* HAXButton.h */,
+				C3E2151D194F381400C85776 /* HAXButton.m */,
 				D4D2103512D6959400509E57 /* HAXElement.h */,
 				D44E051312D75B3D00541D6A /* HAXElement+Protected.h */,
 				D4D2103612D6959400509E57 /* HAXElement.m */,
 				D4D2105312D698F200509E57 /* HAXSystem.h */,
 				D4D2105412D698F400509E57 /* HAXSystem.m */,
+				C3E21528194F38FB00C85776 /* HAXView.h */,
+				C3E21529194F38FB00C85776 /* HAXView.m */,
 				D4D2108012D6A08600509E57 /* HAXWindow.h */,
 				D4D2108112D6A08800509E57 /* HAXWindow.m */,
 			);
@@ -125,9 +143,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4D2105912D6991900509E57 /* HAXSystem.h in Headers */,
+				C3E2152A194F38FB00C85776 /* HAXView.h in Headers */,
 				D4D2103712D6959400509E57 /* HAXElement.h in Headers */,
 				D4D2113E12D6AB0400509E57 /* HAXApplication.h in Headers */,
+				C3E21520194F381400C85776 /* HAXButton.h in Headers */,
 				D4D2113F12D6AB0400509E57 /* HAXWindow.h in Headers */,
+				C3E21526194F38BE00C85776 /* NSScreen+HAXPointConvert.h in Headers */,
 				D4D2113D12D6AAF000509E57 /* Haxcessibility.h in Headers */,
 				BC3B3B76175E9FD4002AD452 /* HAXElement+Protected.h in Headers */,
 			);
@@ -201,10 +222,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C3E2152B194F38FB00C85776 /* HAXView.m in Sources */,
 				D4D2103812D6959400509E57 /* HAXElement.m in Sources */,
+				C3E21521194F381400C85776 /* HAXButton.m in Sources */,
 				D4D2105512D698F400509E57 /* HAXSystem.m in Sources */,
 				D4D2106D12D69C8B00509E57 /* HAXApplication.m in Sources */,
 				D4D2108212D6A08800509E57 /* HAXWindow.m in Sources */,
+				C3E21527194F38BE00C85776 /* NSScreen+HAXPointConvert.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -266,6 +290,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = NS_BUILD_32_LIKE_64;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -282,6 +307,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = NS_BUILD_32_LIKE_64;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
 			};
 			name = Release;

--- a/Other Sources/Haxcessibility.h
+++ b/Other Sources/Haxcessibility.h
@@ -6,3 +6,5 @@
 #import <Haxcessibility/HAXSystem.h>
 #import <Haxcessibility/HAXApplication.h>
 #import <Haxcessibility/HAXWindow.h>
+#import <Haxcessibility/HAXView.h>
+#import <Haxcessibility/HAXButton.h>


### PR DESCRIPTION
This contains a lot of good stuff:
* New `HAXView` type for representing views
 * `HAXWindow` is now a subtype of `HAXView`
* New `HAXButton` type allowing for easy pressing of buttons
* New method `getAttributeValueForKey:error:` in `HAXElement`, reducing the number of places that have to call `CFBridgingRelease`
* Identification of whether a window is full-screen
* Identification of which screen a window (mostly) resides
* `frame` and `origin` now reflect Cocoa coordinates, with `carbonFrame` and `carbonOrigin` counterparts (fixes https://github.com/numist/Haxcessibility/issues/3)
* Various bug fixes and improvements